### PR TITLE
Update to match version of the flash library provided with the 13 tools.

### DIFF
--- a/module_flash/include/flash.h
+++ b/module_flash/include/flash.h
@@ -15,6 +15,7 @@
 
 #ifndef _flash_h_
 #define _flash_h_
+#include <xs1_clock.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -353,7 +354,20 @@ int fl_startImageRead(fl_BootImageInfo &bootImageInfo);
  * \param page Array to fill with image data.
  * \return 0 on success, non zero on failure.
  */
-int fl_readImageRead(unsigned char page[]);
+int fl_readImagePage(unsigned char page[]);
+
+/**
+ * fl_readImageRead is deprecated - use fl_readImagePage instead.
+ */
+#ifdef __XC__
+#define fl_readImageRead(page) _Pragma("warning \"fl_readImageRead is deprecated, use fl_readImagePage instead\"") fl_readImagePage(page)
+#else
+__attribute__((deprecated)) static inline int fl_readImageRead(unsigned char page[])
+{
+  return fl_readImagePage(page);
+}
+#endif
+
 
 /* Data partition functions. */
 

--- a/module_flash/specs/MICRON_M25P40.spispec
+++ b/module_flash/specs/MICRON_M25P40.spispec
@@ -1,0 +1,23 @@
+    MICRON_M25P40,
+    256,                    /* page size */
+    2048,                   /* num pages */
+    3,                      /* address size */
+    8,                      /* log2 clock divider */
+    0x9f,                   /* SPI_RDID */
+    0,                      /* id dummy bytes */
+    3,                      /* id size in bytes */
+    0x202013,               /* device id */
+    0xd8,                   /* SPI_SE */
+    0,                      /* full sector erase */
+    0x06,                   /* SPI_WREN */
+    0x04,                   /* SPI_WRDI */
+    PROT_TYPE_SR,           /* SR protection */
+    {{0x1c,0x0},{0,0}},     /* no values */
+    0x02,                   /* SPI_PP */
+    0x0b,                   /* SPI_READFAST */
+    1,                      /* 1 read dummy byte */
+    SECTOR_LAYOUT_REGULAR,  /* sane sectors */
+    {65536,{0,{0}}},        /* regular sector size */
+    0x05,                   /* SPI_RDSR */
+    0x01,                   /* no SPI_WRSR */
+    0x01,                   /* SPI_WIP_BIT_MASK */

--- a/module_flash/specs/SPANSION_S25FL204K.spispec
+++ b/module_flash/specs/SPANSION_S25FL204K.spispec
@@ -1,0 +1,23 @@
+    SPANSION_S25FL204K,     /* S25FL204K */
+    256,                    /* page size */
+    2048,                   /* num pages */
+    3,                      /* address size */
+    8,                      /* log2 clock divider */
+    0x9F,                   /* SPI_RDID */
+    0,                      /* id dummy bytes */
+    3,                      /* id size in bytes */
+    0x014013,               /* device id */
+    0x20,                   /* SPI_BE4 */
+    4096,                   /* Sector erase is always 4KB */
+    0x06,                   /* SPI_WREN */
+    0x04,                   /* SPI_WRDI */
+    PROT_TYPE_SECS,         /* no protection */
+    {{0,0},{0x36,0x39}},    /* SPI_SP, SPI_SU */
+    0x02,                   /* SPI_PP */
+    0x0B,                   /* SPI_READ_FAST */
+    1,                      /* 1 read dummy byte */
+    SECTOR_LAYOUT_REGULAR,  /* mad sectors */
+    {65536,{0,{0}}},        /* regular sector sizes */
+    0x05,                   /* SPI_RDSR */
+    0x01,                   /* SPI_WRSR */
+    0x01,                   /* SPI_WIP_BIT_MASK */

--- a/module_flash/src/BuildLists.pl
+++ b/module_flash/src/BuildLists.pl
@@ -22,8 +22,8 @@ $xflashFileName = $ARGV[4]; # "XflashCode.cpp";
 @enumorder = ( "ALTERA_EPCS1",    "ATMEL_AT25DF041A", "ST_M25PE10",     "ST_M25PE20",     "ATMEL_AT25FS010",
                "WINBOND_W25X40",  "AMIC_A25L016",     "AMIC_A25L40PT",  "AMIC_A25L40PUM", "AMIC_A25L80P",
                "ATMEL_AT25DF021", "ATMEL_AT25F512",   "ESMT_F25L004A",  "NUMONYX_M25P10", "NUMONYX_M25P16",
-               "NUMONYX_M45P10E", "SST_SST25VF010",   "SST_SST25VF016", "SST_SST25VF040", "WINBOND_W25X10",
-               "WINBOND_W25X20",  "AMIC_A25L40P",     "MACRONIX_MX25L1005C" );
+               "NUMONYX_M45P10E", "SPANSION_S25FL204K", "SST_SST25VF010",   "SST_SST25VF016", "SST_SST25VF040", 
+               "WINBOND_W25X10", "WINBOND_W25X20",  "AMIC_A25L40P",     "MACRONIX_MX25L1005C" , "MICRON_M25P40" );
 
 #
 # Some names which should be listed in xflash last to avoid confusion between devices.

--- a/module_flash/src/DeviceAccess.xc
+++ b/module_flash/src/DeviceAccess.xc
@@ -216,12 +216,12 @@ int fl_int_programPage( const fl_DeviceSpec& flashAccess, unsigned int pageAddre
 }
 
 #pragma unsafe arrays
-static void fl_int_readPageBlock( in buffered port:8 prt, unsigned char data[], unsigned int numBytes )
+static void fl_int_readPageBlock(unsigned char data[], unsigned int numBytes )
 {
   unsigned int tmp;
   for (int i=0; i<numBytes; i++)
   {
-    prt :> tmp;
+    g_portHolder.spiMISO :> tmp;
     data[i] = bitrev(tmp<<24);
   }
   stop_clock(g_portHolder.spiClkblk);
@@ -250,7 +250,7 @@ int fl_int_readBytes(const fl_DeviceSpec& flashAccess, unsigned pageAddress,
     g_portHolder.spiMISO :> void;
   }
 
-  fl_int_readPageBlock( g_portHolder.spiMISO, data, numBytes );
+  fl_int_readPageBlock( data, numBytes );
 
   g_portHolder.spiSS  <: 0x1;
   return(0);


### PR DESCRIPTION
Without this change it sc_flash won't work with upgrade images produce by the 13 tools since the tag used to identify them has changed.
